### PR TITLE
Semver releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ notifications:
   email: false
 before_install:
   - set -e
+  # Add ssh key w/ write permission for `as24-custom-events` repo
+  - openssl aes-256-cbc -K $encrypted_ab46abe2afd1_key -iv $encrypted_ab46abe2afd1_iv -in travis_ci_rsa.enc -out ./travis_ci_rsa -d
+  - chmod 600 travis_ci_rsa
+  - eval `ssh-agent -s`
+  - ssh-add travis_ci_rsa
 install:
   - yarn install
   - yarn global add codecov
@@ -17,12 +22,20 @@ script:
   - yarn run build
 after_success:
   - codecov
-before_deploy:
-  # Add ssh key w/ write permission for `as24-custom-events` repo
-  - openssl aes-256-cbc -K $encrypted_ab46abe2afd1_key -iv $encrypted_ab46abe2afd1_iv -in travis_ci_rsa.enc -out ./travis_ci_rsa -d
-  - chmod 600 travis_ci_rsa
-  - eval `ssh-agent -s`
-  - ssh-add travis_ci_rsa
+  - |
+    # Check if we need to do SEMVER bump based on commit's parent PR labels
+    # - only run for master branch we don't want to release PRs and other branches
+    # - only run on non-tagged releases, this will bump the version, tag, commit & push back to github
+    if [ "$TRAVIS_PULL_REQUEST" != "true" ] && [ -z "$TRAVIS_TAG" ] && [ "$TRAVIS_BRANCH" == "master" ]; then 
+      echo "Travis commit: $TRAVIS_COMMIT"
+      SEMVER_BUMP=$(./semver_from_pr_labels.sh $TRAVIS_COMMIT 2>/dev/null)
+      echo $SERVER_BUMP
+      if [ -z "$SERVER_BUMP" ]; then
+        echo "Bumping package version for $SEMVER_BUMP release and pushing tag to github"
+        yarn version --new-version $SEMVER_BUMP
+        git push --follow-tags
+      fi
+    fi
 deploy:
   - provider: npm
     email: '#AS24-Web-Experience-Team-ds@scout24.com'

--- a/semver_from_pr_labels.sh
+++ b/semver_from_pr_labels.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Given a commit, it finds the originating PR and determines semver bump based on labels
+#
+# Usage:
+# ./semver_from_pr_labels.sh <SHA>
+#
+# Labels to semver bump:
+#  - release:bugfix -> patch
+#  - release:enhacement -> minor
+#  - release:breaking -> breaking
+#
+# References: 
+# - https://stackoverflow.com/questions/31887253/value-map-with-jq
+
+set -e
+
+# command will throw if there are no labels associated to the PR because of the unsafe items[0] selector
+curl -s https://api.github.com/search/issues?q=${1}+type:pr+is:merged+repo:Scout24/as24-custom-events \
+  | jq -r '.items[0] .labels[] | select(.name | contains("release:enhancement")) | .name = (if .name =="release:breaking" then "major" elif .name == "release:enhancement" then "minor" else "patch" end) | .name'
+  


### PR DESCRIPTION
- Add semver logic for after successful builds to see if we need to generate a new package version
- If a travis build happens on master branch with an untagged commit, it'll check parent PR release labels to determine proper version bump
- If these semver is successfully determined, it will bump version, tag, commit & push back to github master branch.
- This second commit is tagged, will be built and then deployed to npm & github

(untested)