### PR TITLE
Added request/response events to get the current filters from CL

### DIFF
--- a/__tests__/pages/__snapshots__/listpage.test.ts.snap
+++ b/__tests__/pages/__snapshots__/listpage.test.ts.snap
@@ -11,3 +11,5 @@ exports[`listpage events event names must never change 4`] = `"SAVED_SEARCHES_FR
 exports[`listpage events event names must never change 5`] = `"LIST_ITEMS_INITIALIZED"`;
 
 exports[`listpage events event names must never change 6`] = `"WEB_PUSH:OPT_IN"`;
+
+exports[`listpage events event names must never change 7`] = `"CLASSIFIED_LIST:REQUEST_FILTER_VALUES"`;

--- a/__tests__/pages/listpage.test.ts
+++ b/__tests__/pages/listpage.test.ts
@@ -7,7 +7,8 @@ describe('listpage events', () => {
     p.ListItemsChanged,
     p.SavedSearchesFragmentInitialization,
     p.ListItemsInitialized,
-    p.WebPushOptIn
+    p.WebPushOptIn,
+    p.ClassifiedListRequestFiltersValue
   ]
 
   test.each(eventNames)('event names must never change', eventName => {
@@ -21,6 +22,7 @@ describe('listpage events', () => {
     document.addEventListener(p.ListItemsInitialized, e => e.detail as undefined)
     document.addEventListener(p.SavedSearchesFragmentInitialization, e => e.detail as undefined)
     document.addEventListener(p.WebPushOptIn, e => e.detail.as24Visitor as string)
+    document.addEventListener(p.ClassifiedListRequestFiltersValue, e => e.detail as undefined)
     expect(true).toBeTruthy() // dummy assertion since compiler check is the real test
   })
 })

--- a/src/pages/listpage.ts
+++ b/src/pages/listpage.ts
@@ -52,10 +52,17 @@ export type ListItemsInitialized = undefined
 export const SavedSearchesFragmentInitialization = 'SAVED_SEARCHES_FRAGMENT_INIT'
 export type SavedSearchesFragmentInitialization = undefined
 
+/**
+ * Retrieve the current filters. The list page will fire a CL_FILTER_UPDATE as a response
+ */
+export const ClassifiedListRequestFiltersValue = 'CLASSIFIED_LIST:REQUEST_FILTER_VALUES'
+export type ClassifiedListRequestFiltersValue = undefined
+
 // inform compiler of the as24 custom events
 declare global {
   interface DocumentEventMap {
     [ClassifiedListFilterUpdate]: CustomEvent<ClassifiedListFilterUpdate>
+    [ClassifiedListRequestFiltersValue]: CustomEvent<ClassifiedListRequestFiltersValue>
     [ClassifiedListTotalCountUpdate]: CustomEvent<ClassifiedListTotalCountUpdate>
     [SavedSearchesFragmentInitialization]: CustomEvent<SavedSearchesFragmentInitialization>
     [ListItemsChanged]: CustomEvent<ListItemsChanged>


### PR DESCRIPTION
Added new event that will be included in the List page to retrieve the current filters.
The page will answer with a `CL_FILTER_UPDATE`