### PR TITLE
Added event for the edit page in saved searches

### DIFF
--- a/__tests__/pages/__snapshots__/savedSearchesEdit.test.ts.snap
+++ b/__tests__/pages/__snapshots__/savedSearchesEdit.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`page events event names must never change 1`] = `"SAVED_SEARCHES_EDIT:SEARCH_MASK_QUERY_UPDATE"`;

--- a/__tests__/pages/savedSearchesEdit.test.ts
+++ b/__tests__/pages/savedSearchesEdit.test.ts
@@ -1,0 +1,14 @@
+import * as p from '../../src/pages/savedSearchesEdit'
+
+describe('page events', () => {
+  const eventNames = [p.SearchMaskFilterUpdate]
+
+  test.each(eventNames)('event names must never change', eventName => {
+    expect(eventName).toMatchSnapshot()
+  })
+
+  test('type definitions are inferred correctly by compiler', () => {
+    document.addEventListener(p.SearchMaskFilterUpdate, e => e.detail.query)
+    expect(true).toBeTruthy() // dummy assertion since compiler check is the real test
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,11 @@ import * as Example from './pages/example'
 import * as Global from './pages/global'
 import * as HomePage from './pages/homepage'
 import * as ListPage from './pages/listpage'
+import * as SavedSearchesEdit from './pages/savedSearchesEdit'
 
 export { default as strictCustomEvent } from './constructors/strictCustomEvent'
 
+export { SavedSearchesEdit }
 export { ListPage }
 export { HomePage }
 export { Example }

--- a/src/pages/savedSearchesEdit.ts
+++ b/src/pages/savedSearchesEdit.ts
@@ -1,0 +1,13 @@
+/**
+ * Update search mask query
+ */
+export const SearchMaskFilterUpdate = 'SAVED_SEARCHES_EDIT:SEARCH_MASK_QUERY_UPDATE'
+export type SearchMaskFilterUpdate = {
+  query: string
+}
+
+declare global {
+  interface DocumentEventMap {
+    [SearchMaskFilterUpdate]: CustomEvent<SearchMaskFilterUpdate>
+  }
+}


### PR DESCRIPTION
The event will allow to update the search mask fragment.
The payload is the query string