### PR TITLE
Adds new view change event to home page

### DIFF
--- a/__tests__/pages/homepage.test.ts
+++ b/__tests__/pages/homepage.test.ts
@@ -1,13 +1,14 @@
 import * as p from '../../src/pages/homepage'
 
 describe('homepage events', () => {
-  const eventNames: string[] = []
+  const eventNames: string[] = [p.ViewChange]
 
   test.each(eventNames)('event names must never change', eventName => {
-    expect(eventName).toMatchSnapshot()
+    expect(eventName).toMatchInlineSnapshot(`"VIEW_CHANGE"`)
   })
 
   test('type definitions are inferred correctly by compiler', () => {
+    document.addEventListener(p.ViewChange, e => e.detail.view as 'aisearch' | 'filters')
     expect(true).toBeTruthy() // dummy assertion since compiler check is the real test
   })
 })

--- a/src/pages/homepage.ts
+++ b/src/pages/homepage.ts
@@ -5,9 +5,15 @@ export type TestEvent = {
   foo: boolean
 }
 
+export const ViewChange = 'VIEW_CHANGE'
+export type ViewChange = {
+  view: 'aisearch' | 'filters'
+}
+
 // Add events to Document
 declare global {
   interface DocumentEventMap {
     [TestEvent]: CustomEvent<TestEvent>
+    [ViewChange]: CustomEvent<ViewChange>
   }
 }


### PR DESCRIPTION
Adds new view change event to home page to track switch between filter home mask and ai search